### PR TITLE
Fix section ordering based on the appearance in the data set

### DIFF
--- a/src/BMCollectionView.runtime.ts
+++ b/src/BMCollectionView.runtime.ts
@@ -2856,8 +2856,8 @@ implements BMCollectionViewDelegate, BMCollectionViewDataSet, BMCollectionViewDe
 					let section;
 					
 					if (!(section = sectionIdentifiers[sectionIdentifier])) {
-						section = sectionIdentifiers[sectionIdentifier] = {rows: [], identifier: sectionIdentifier};
 						sectionIndex++;
+						section = sectionIdentifiers[sectionIdentifier] = {rows: [], identifier: sectionIdentifier, index: sectionIndex};
 					}
 					
 					// When using the sortField, the index no longer matches the object's original position within the Infotable
@@ -2868,6 +2868,8 @@ implements BMCollectionViewDelegate, BMCollectionViewDataSet, BMCollectionViewDe
 				}
 				
 				var keys = Object.keys(sectionIdentifiers);
+				// Sort the section keys by their index to retain the original order 
+				keys.sort((k1, k2) => sectionIdentifiers[k1].index - sectionIdentifiers[k2].index);
 				for (var i = 0; i < keys.length; i++) {
 					this.sections.push(sectionIdentifiers[keys[i]]);
 				}


### PR DESCRIPTION
# Intent
When configuring the collection to use sections, the order of cells is not always preserved, and sorting based on the `sortField` can sometimes be ignored.

# Implementation
When creating sections, they are stored in an object called `sectionIdentifiers`. While iterating over the data set, each row's `sectionField` value is mapped to its corresponding section key. After all rows have been processed, the keys of this object are iterated to populate the collection's `sections` property.

This approach relies on the order in which the keys were created being preserved when retrieved, which is not guaranteed. As a result, sections may be added to the collection in an incorrect order.

To address this, we use a `sectionIndex` variable and store it on the section object in `sectionIdentifiers`. Before populating the `sections` array, the keys are sorted based on this property, ensuring sections are added in the order they first appear in the data set.